### PR TITLE
fix: improve native example viewer

### DIFF
--- a/examples/example_native.py
+++ b/examples/example_native.py
@@ -1,7 +1,8 @@
 import argparse
+import platform
+import sys
 import time
 
-import matplotlib.pyplot as plt
 import mujoco
 import mujoco.viewer
 import numpy as np
@@ -9,24 +10,59 @@ from etils import epath
 
 from mujoco_lidar import MjLidarWrapper, scan_gen
 
+_MACOS_VIEWER_HELP = """\
+On macOS, MuJoCo's viewer must run under mjpython.
+
+  uv run mjpython examples/example_native.py
+
+If mjpython fails with "Library not loaded: @rpath/libpython...", link libpython into .venv:
+
+  uv run python -c "import sys, sysconfig, pathlib; lib=pathlib.Path(sysconfig.get_config_var('LIBDIR'))/f'libpython{sys.version_info.major}.{sys.version_info.minor}.dylib'; t=pathlib.Path('.venv')/lib.name; t.unlink(missing_ok=True); t.symlink_to(lib); print(t, '->', lib)"
+"""
+
+
+def _height_rgba(z_norm: np.ndarray) -> np.ndarray:
+    rgba = np.empty((z_norm.shape[0], 4), dtype=np.float64)
+    rgba[:, 0] = z_norm
+    rgba[:, 1] = 1.0 - np.abs(z_norm - 0.5) * 2.0
+    rgba[:, 2] = 1.0 - z_norm
+    rgba[:, 3] = 0.8
+    return rgba
+
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="MuJoCo LiDAR native viewer example")
+    parser = argparse.ArgumentParser(description="MID360 LiDAR demo (MuJoCo native viewer)")
     parser.add_argument(
         "--backend",
         type=str,
-        default="taichi",
+        default="cpu",
         help="LiDAR后端 (cpu, taichi, jax, warp)",
         choices=["cpu", "taichi", "jax", "warp"],
     )
+    parser.add_argument(
+        "--downsample",
+        type=int,
+        default=6,
+        help="Ray stride for mid360 (default 6 -> 4000 rays; use 1 for full 24000)",
+    )
+    parser.add_argument(
+        "--rate",
+        type=float,
+        default=12.0,
+        help="LiDAR update rate in Hz (default 12)",
+    )
     args = parser.parse_args()
+    if args.downsample < 1:
+        parser.error("--downsample must be >= 1")
+    if args.rate <= 0:
+        parser.error("--rate must be > 0")
 
     mjcf_file = epath.Path(__file__).parent.parent / "models" / "demo.xml"
     mj_model = mujoco.MjModel.from_xml_path(mjcf_file.as_posix())
     mj_data = mujoco.MjData(mj_model)
 
-    update_rate = 12.0  # Hz
-    n_substeps = int(round(1.0 / (mj_model.opt.timestep * update_rate)))
-    print(f"n_substeps = {n_substeps}")
+    n_substeps = int(round(1.0 / (mj_model.opt.timestep * args.rate)))
+    print(f"n_substeps = {n_substeps} (physics steps per LiDAR frame)")
 
     lidar = MjLidarWrapper(
         mj_model,
@@ -35,57 +71,50 @@ if __name__ == "__main__":
         args={"bodyexclude": mj_model.body("your_robot_name").id},
     )
     livox_generator = scan_gen.LivoxGenerator("mid360")
-    rays_theta, rays_phi = livox_generator.sample_ray_angles()
+    rays_theta, rays_phi = livox_generator.sample_ray_angles(downsample=args.downsample)
+    n_rays = rays_theta.shape[0]
+
+    if platform.system() == "Darwin" and mujoco.viewer._MJPYTHON is None:
+        sys.exit(_MACOS_VIEWER_HELP)
 
     with mujoco.viewer.launch_passive(mj_model, mj_data) as viewer:
-        viewer.user_scn.ngeom = rays_theta.shape[0]
-        for i in range(viewer.user_scn.ngeom):
+        viewer.user_scn.ngeom = n_rays
+        for i in range(n_rays):
             mujoco.mjv_initGeom(
                 viewer.user_scn.geoms[i],
                 type=mujoco.mjtGeom.mjGEOM_SPHERE,
-                size=[0.02, 0, 0],
+                size=[0.03, 0, 0],
                 pos=[0, 0, 0],
                 mat=np.eye(3).flatten(),
                 rgba=np.array([1, 0, 0, 0.8]),
             )
 
         print("Starting simulation...")
-        print("Number of rays:", rays_theta.shape[0])
-        cmap = plt.get_cmap("hsv")  # 或使用 'jet', 'viridis', 'plasma' 等
+        print(f"Rays per scan: {n_rays} (downsample={args.downsample})")
 
-        _last_time = 1e6
+        geoms = viewer.user_scn.geoms
+        _start_time = time.time()
         while viewer.is_running():
-            mujoco.mj_step(mj_model, mj_data)
+            for _ in range(n_substeps):
+                mujoco.mj_step(mj_model, mj_data)
 
-            if mj_data.time < _last_time:
-                _counter = 0
-                _start_time = time.time()
-            _last_time = mj_data.time
+            rays_theta, rays_phi = livox_generator.sample_ray_angles(downsample=args.downsample)
+            lidar.trace_rays(mj_data, rays_theta, rays_phi)
+            points = lidar.get_hit_points()
+            world_points = points @ lidar.sensor_rotation.T + lidar.sensor_position
 
-            _counter += 1
-            if _counter % n_substeps == 0:
-                rays_theta, rays_phi = livox_generator.sample_ray_angles()
-                lidar.trace_rays(mj_data, rays_theta, rays_phi)
-                points = lidar.get_hit_points()
-                world_points = points @ lidar.sensor_rotation.T + lidar.sensor_position
+            z_values = world_points[:, 2]
+            z_min, z_max = z_values.min(), z_values.max()
+            z_norm = (
+                (z_values - z_min) / (z_max - z_min) if z_max > z_min else np.zeros_like(z_values)
+            )
+            colors = _height_rgba(z_norm)
 
-                # 根据高度设置颜色
-                z_values = world_points[:, 2]
-                z_min, z_max = z_values.min(), z_values.max()
-                if z_max > z_min:
-                    # 归一化高度值到 [0, 1]
-                    z_norm = (z_values - z_min) / (z_max - z_min)
-                else:
-                    z_norm = np.zeros_like(z_values)
-
-                # 使用 matplotlib 颜色映射
-                colors = cmap(z_norm)  # 返回 RGBA 值，shape: (N, 4)
-
-                for i in range(viewer.user_scn.ngeom):
-                    viewer.user_scn.geoms[i].pos[:] = world_points[i]
-                    viewer.user_scn.geoms[i].rgba[:] = colors[i]
+            for i in range(n_rays):
+                geoms[i].pos[:] = world_points[i]
+                geoms[i].rgba[:] = colors[i]
 
             viewer.sync()
-            run_time = time.time() - _start_time
-            if run_time < mj_data.time:
-                time.sleep(mj_data.time - run_time)
+            elapsed = time.time() - _start_time
+            if elapsed < mj_data.time:
+                time.sleep(mj_data.time - elapsed)


### PR DESCRIPTION
Ports the usable parts of #14 onto current main.

Changes:
- Default native example backend to CPU while keeping the backend CLI option.
- Add --downsample and --rate controls for MID360 scans.
- Batch physics steps per LiDAR frame and sync the viewer once per scan.
- Replace the example's per-frame matplotlib colormap with a NumPy height-to-RGBA helper.
- Show macOS mjpython launch instructions before starting the passive viewer.

Verification:
- uv run --python 3.12 --extra examples --extra dev python -m py_compile examples/example_native.py
- uv run --python 3.12 --extra dev python -m ruff format --check examples/example_native.py