### PR TITLE
release: v0.3.4

### DIFF
--- a/src/mujoco_lidar/__init__.py
+++ b/src/mujoco_lidar/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from mujoco_lidar.lidar_wrapper import MjLidarWrapper
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 __all__ = [
     "MjLidarWrapper",

--- a/src/mujoco_lidar/core_warp/geometry.py
+++ b/src/mujoco_lidar/core_warp/geometry.py
@@ -92,7 +92,7 @@ def ray_cylinder_distance(
 ):
     ro, rd = transform_ray_to_local(ray_origin, ray_dir, center, rot)
     radius = size[0]
-    half_height = size[1]
+    half_height = size[2]
     best = 1.0e20
 
     a = rd[0] * rd[0] + rd[1] * rd[1]
@@ -174,7 +174,7 @@ def ray_capsule_distance(
 ):
     ro, rd = transform_ray_to_local(ray_origin, ray_dir, center, rot)
     radius = size[0]
-    half_height = size[1]
+    half_height = size[2]
     best = ray_cylinder_distance(ray_origin, ray_dir, center, size, rot)
     if best < 0.0:
         best = 1.0e20

--- a/tests/test_warp_backend.py
+++ b/tests/test_warp_backend.py
@@ -200,3 +200,31 @@ def test_warp_backend_hfield_matches_cpu():
     warp_ranges = warp_lidar.trace_rays(data, theta, phi)
 
     np.testing.assert_allclose(warp_ranges, cpu_ranges, atol=1e-5)
+
+
+def test_warp_backend_capsule_cylinder_match_cpu():
+    xml = """
+    <mujoco>
+      <worldbody>
+        <geom type="capsule" pos="2 0 0.5" quat="0.7071068 0 0.7071068 0" size="0.3 0.8"/>
+        <geom type="capsule" pos="0 3 -0.2" size="0.2 0.5"/>
+        <geom type="cylinder" pos="-2 0 0" size="0.4 0.9"/>
+        <site name="lidar_site" pos="0 0 0"/>
+      </worldbody>
+    </mujoco>
+    """
+    model = mujoco.MjModel.from_xml_string(xml)
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+
+    rng = np.random.default_rng(0)
+    theta = rng.uniform(0, np.pi, 2000).astype(np.float32)
+    phi = rng.uniform(-np.pi / 2, np.pi / 2, 2000).astype(np.float32)
+
+    cpu_lidar = MjLidarWrapper(model, site_name="lidar_site", backend="cpu")
+    warp_lidar = MjLidarWrapper(model, site_name="lidar_site", backend="warp")
+
+    cpu_ranges = cpu_lidar.trace_rays(data, theta, phi)
+    warp_ranges = warp_lidar.trace_rays(data, theta, phi)
+
+    np.testing.assert_allclose(warp_ranges, cpu_ranges, atol=1e-5)


### PR DESCRIPTION
fix: warp 后端 cylinder/capsule 半高读取槽位错误（size[1] -> size[2]，与 taichi/tibvh 约定一致），新增 warp vs cpu 胶囊/圆柱对照回归测试，版本号升至 0.3.4。